### PR TITLE
Fix auth login encoding

### DIFF
--- a/src/services/authTester.ts
+++ b/src/services/authTester.ts
@@ -132,13 +132,14 @@ export class AuthenticationTester {
     
     try {
       // Simulate form-based login
-      const loginData = new FormData();
+      // Use URLSearchParams so the Content-Type header matches the body
+      const loginData = new URLSearchParams();
       loginData.append('username', credentials.username);
       loginData.append('password', credentials.password);
 
       const response = await fetch(`${url}/login`, {
         method: 'POST',
-        body: loginData,
+        body: loginData.toString(),
         credentials: 'include',
         headers: {
           'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
## Summary
- fix form-based auth request body encoding

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6846b2233c4c83319c676a54a06bce0d